### PR TITLE
Added support for redis cluster mode via ioredis

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,13 @@ module.exports = {
 }
 ```
 
-## Redis Cluster config
+## Passing your own Redis Client
+
+You can also provide an [ioredis](https://github.com/luin/ioredis) client or or cluster instance if you need advanced configuration
 
 ```javascript
 cacheAdapter: RedisCache.init({
-    cluster: [
-      {
-        host: '<your-host>'
-        port: '<your-port>'
-      },
-      {
-        host: '<your-host-2>'
-        port: '<your-port-2>'
-      },
-      ...
-    ],
+    redis: new Redis.Cluster({...}),
     ttl: 15,
     tbd: 3600,
 })

--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ module.exports = {
 }
 ```
 
+## Redis Cluster config
+
+```javascript
+cacheAdapter: RedisCache.init({
+    cluster: [
+      {
+        host: '<your-host>'
+        port: '<your-port>'
+      },
+      {
+        host: '<your-host-2>'
+        port: '<your-port-2>'
+      },
+      ...
+    ],
+    ttl: 15,
+    tbd: 3600,
+})
+```
+
 ## License
 
 MIT. Copyright 2020, Rakuraku Jyo.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "flatted": "^3.2.5",
     "ioredis": "^4.28.2"
   },
   "devDependencies": {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,4 +1,5 @@
 import Cache, { CacheOptions } from './'
+import { stringify } from 'flatted'
 
 export class Adapter {
   cache?: Cache
@@ -19,7 +20,7 @@ export class Adapter {
 
   async init() {
     this.cache = new Cache(this.options)
-    console.log(`  Redis cache inited: ${JSON.stringify(this.options)}`)
+    console.log(`  Redis cache inited: ${stringify(this.options)}`)
     return this.cache
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,7 @@ export interface CacheOptions {
   uri?: string
   ttl?: number
   tbd?: number
-  cluster?: Array<{
-    port: number
-    host: string
-  }>
+  redis?: Redis.Redis | Redis.Cluster
 }
 
 class Cache {
@@ -19,10 +16,10 @@ class Cache {
   ttl = 3600 // time to live
   tbd = 3600 // time before deletion
 
-  constructor({ uri, ttl, tbd, cluster }: CacheOptions = {}) {
+  constructor({ uri, ttl, tbd, redis }: CacheOptions = {}) {
     try {
-      if (cluster) {
-        this.redis = new Redis.Cluster(cluster)
+      if (redis) {
+        this.redis = redis
       } else {
         this.redis = new Redis(uri || 'redis://127.0.1:6379')
       }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,70 +6,98 @@ export const sleep = async (t: number) => {
   return new Promise((resolve) => setTimeout(resolve, t))
 }
 
-describe('redis cache with ttl', () => {
-  let cache: Cache
+const configs = [
+  {
+    uri: process.env.REDIS_URL,
+    ttl: 100,
+    tbd: 300,
+    title: 'redis cache with ttl',
+  },
+  {
+    cluster: [
+      {
+        host: process.env.REDIS_CLUSER_HOST || '127.0.0.1 ',
+        port: Number.parseInt(process.env.REDIS_CLUSTER_PORT || '6379'),
+      },
+    ],
+    ttl: 100,
+    tbd: 30,
+    title: 'redis cluster cache with ttl',
+  },
+]
 
-  before(async () => {
-    cache = new Cache({ uri: process.env.REDIS_URL, ttl: 100, tbd: 300 })
+for (const config of configs) {
+  describe(config.title, () => {
+    let cache: Cache
+    const { uri, ttl, tbd, cluster } = config
+    before(async () => {
+      const start = Date.now()
+      cache = new Cache({ uri, ttl, tbd, cluster })
 
-    await cache.del('miss')
-    await cache.del('hit')
-    await cache.del('stale')
+      await cache.del('miss')
+      await cache.del('hit')
+      await cache.del('stale')
+      const finish = Date.now()
+      console.log(`redis startup time: ${finish - start}ms`)
+    })
+
+    after(async () => {
+      cache.redis.disconnect()
+    })
+
+    it('set / get', async () => {
+      const v = Buffer.from('B')
+      const start = Date.now()
+      await cache.set('A', v)
+      const finish = Date.now()
+      console.log(`set / get time: ${finish - start}ms`)
+      expect(await cache.get('A')).to.deep.eq(v)
+
+      const v2 = Buffer.from('AAA')
+      await cache.set('A', v2)
+      expect(await cache.get('A')).to.deep.eq(v2)
+
+      const defaultValue = Buffer.from('AA')
+      expect(await cache.get('B', defaultValue)).to.eq(defaultValue)
+    })
+
+    it('set / get stale / hit / miss', async () => {
+      const key = 'key:1'
+      await cache.set(key, Buffer.from('1'), 0.8)
+      let s = await cache.has(key)
+      expect(s).to.eq('hit')
+      await sleep(1000)
+      s = await cache.has(key)
+      expect(s).to.eq('stale')
+      const v = await cache.get(key)
+      expect(v).to.deep.eq(Buffer.from('1'))
+      s = await cache.has('key:2')
+      expect(s).to.eq('miss')
+    })
+
+    it('set / get large buffer', async () => {
+      const key1 = 'key:l1'
+      const d = new Array(20000).fill('A')
+      const buf = Buffer.from(d)
+      await cache.set(key1, buf, 0.8)
+      expect(await cache.get(key1)).to.deep.eq(buf)
+    })
+
+    it('del / get miss', async () => {
+      await cache.set('A', Buffer.from('1'))
+      expect(await cache.get('A')).to.deep.eq(Buffer.from('1'))
+      await cache.del('A')
+      expect(await cache.get('A')).to.be.undefined
+      await cache.del('not-exist')
+    })
+
+    it('inc, count', async () => {
+      await cache.inc('miss')
+      expect(await cache.count(['miss'])).to.deep.eq([1])
+
+      await cache.inc('hit')
+      await cache.inc('miss')
+      expect(await cache.count(['miss', 'hit', 'stale'])).to.deep.eq([2, 1, 0])
+    })
   })
-
-  after(async () => {
-    cache.redis.disconnect()
-  })
-
-  it('set / get', async () => {
-    const v = Buffer.from('B')
-    await cache.set('A', v)
-    expect(await cache.get('A')).to.deep.eq(v)
-
-    const v2 = Buffer.from('AAA')
-    await cache.set('A', v2)
-    expect(await cache.get('A')).to.deep.eq(v2)
-
-    const defaultValue = Buffer.from('AA')
-    expect(await cache.get('B', defaultValue)).to.eq(defaultValue)
-  })
-
-  it('set / get stale / hit / miss', async () => {
-    const key = 'key:1'
-    await cache.set(key, Buffer.from('1'), 0.8)
-    let s = await cache.has(key)
-    expect(s).to.eq('hit')
-    await sleep(1000)
-    s = await cache.has(key)
-    expect(s).to.eq('stale')
-    const v = await cache.get(key)
-    expect(v).to.deep.eq(Buffer.from('1'))
-    s = await cache.has('key:2')
-    expect(s).to.eq('miss')
-  })
-
-  it('set / get large buffer', async () => {
-    const key1 = 'key:l1'
-    const d = new Array(20000).fill('A')
-    const buf = Buffer.from(d)
-    await cache.set(key1, buf, 0.8)
-    expect(await cache.get(key1)).to.deep.eq(buf)
-  })
-
-  it('del / get miss', async () => {
-    await cache.set('A', Buffer.from('1'))
-    expect(await cache.get('A')).to.deep.eq(Buffer.from('1'))
-    await cache.del('A')
-    expect(await cache.get('A')).to.be.undefined
-    await cache.del('not-exist')
-  })
-
-  it('inc, count', async () => {
-    await cache.inc('miss')
-    expect(await cache.count(['miss'])).to.deep.eq([1])
-
-    await cache.inc('hit')
-    await cache.inc('miss')
-    expect(await cache.count(['miss', 'hit', 'stale'])).to.deep.eq([2, 1, 0])
-  })
-})
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,6 @@
 import { expect } from 'chai'
+import { readdirSync } from 'fs'
+import Redis from 'ioredis'
 
 import Cache from '../src'
 
@@ -14,25 +16,31 @@ const configs = [
     title: 'redis cache with ttl',
   },
   {
-    cluster: [
+    redis: new Redis.Cluster([
       {
         host: process.env.REDIS_CLUSER_HOST || '127.0.0.1 ',
         port: Number.parseInt(process.env.REDIS_CLUSTER_PORT || '6379'),
       },
-    ],
+    ]),
     ttl: 100,
     tbd: 30,
-    title: 'redis cluster cache with ttl',
+    title: 'provided redis cluster cache with ttl',
+  },
+  {
+    redis: new Redis(process.env.REDIS_URL),
+    ttl: 100,
+    tbd: 30,
+    title: 'provided redis client cache with ttl',
   },
 ]
 
 for (const config of configs) {
   describe(config.title, () => {
     let cache: Cache
-    const { uri, ttl, tbd, cluster } = config
+    const { uri, ttl, tbd, redis } = config
     before(async () => {
       const start = Date.now()
-      cache = new Cache({ uri, ttl, tbd, cluster })
+      cache = new Cache({ uri, ttl, tbd, redis })
 
       await cache.del('miss')
       await cache.del('hit')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,6 +1077,11 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.4.tgz#28d9969ea90661b5134259f312ab6aa7929ac5e2"
   integrity sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==
 
+flatted@^3.2.5:
+  version "3.2.5"
+  resolved "https://chegg.jfrog.io/chegg/api/npm/npm/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
+  integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
+
 foreground-child@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-2.0.0.tgz#71b32800c9f15aa8f2f83f4a6bd9bff35d861a53"


### PR DESCRIPTION
Add support for passing an ioredis cluster config object to Cache constructor

Update count function to use a promise array instead of mget as mget is not supported for clusters when keys are stored in different slots

For testing purposes, you can use this docker container for a redis cluster: https://github.com/Grokzen/docker-redis-cluster